### PR TITLE
Add support for Hugo (gohugo.io)

### DIFF
--- a/find-generator.js
+++ b/find-generator.js
@@ -54,6 +54,8 @@ class FindGenerator {
       url = "https://www.11ty.dev/";
     } else if(name === "gatsby") {
       url = "https://www.gatsbyjs.com/";
+    } else if(name === "hugo") {
+      url = "https://gohugo.io/";
     } else if(name) {
       // found a generator name but was not supported
       return `./redx.svg`

--- a/test/test.js
+++ b/test/test.js
@@ -32,3 +32,16 @@ test("Image/info for gatsbyjs.com", async t => {
 
   t.truthy(image.body);
 });
+
+test("Image/info for gohugo.io", async t => {
+  let g = new FindGenerator("https://gohugo.io/");
+  await g.fetch();
+
+  let generator = g.findData();
+  let image = await g.getImage(generator);
+
+  t.is(generator.name, "Hugo");
+  t.truthy(generator.version);
+
+  t.truthy(image.body);
+});


### PR DESCRIPTION
Adds support for [Hugo](https://gohugo.io/), which uses `Hugo {version}` format similar to 11ty and Gatsby.